### PR TITLE
Add interactive heading rotation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -13,6 +13,14 @@ function pac_lt_enqueue_assets() {
         null,
         false
     );
+
+    wp_enqueue_script(
+        'pac-rotate',
+        get_template_directory_uri() . '/mouse-rotate.js',
+        [],
+        null,
+        true
+    );
 }
 add_action( 'wp_enqueue_scripts', 'pac_lt_enqueue_assets' );
 add_theme_support( 'title-tag' );

--- a/mouse-rotate.js
+++ b/mouse-rotate.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const heading = document.querySelector('h1');
+  if (!heading) return;
+  const rotate = (event) => {
+    const xPercent = event.clientX / window.innerWidth - 0.5;
+    const yPercent = event.clientY / window.innerHeight - 0.5;
+    const rotateY = xPercent * 30; // left/right
+    const rotateX = -yPercent * 30; // up/down
+    heading.style.transform = `perspective(500px) rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+  };
+  document.addEventListener('mousemove', rotate);
+});
+

--- a/style.css
+++ b/style.css
@@ -13,6 +13,10 @@ body {
 
 h1 {
   font-family: 'Bebas Neue', sans-serif;
+  /* Base style for 3D heading */
+  display: inline-block;
+  transform: perspective(500px) rotateX(0deg) rotateY(0deg);
+  transition: transform 0.2s ease-out;
 }
 
 h2, h3, h4, h5, h6 {


### PR DESCRIPTION
## Summary
- rotate main heading based on mouse movement
- load new `mouse-rotate.js` via `functions.php`
- adjust base heading style so rotation starts at 0deg

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683f77adb9c48323ba3eb5277291269c